### PR TITLE
like検索の変更のため

### DIFF
--- a/lib/ecto/ecto_util.ex
+++ b/lib/ecto/ecto_util.ex
@@ -177,15 +177,7 @@ defmodule MateriaUtils.Ecto.EctoUtil do
 
               "like" ->
                 query
-                |> where([s], like(field(s, ^key), ^"%#{value}%"))
-
-              "forward_like" ->
-                query
-                |> where([s], like(field(s, ^key), ^"#{value}%"))
-
-              "backward_like" ->
-                query
-                |> where([s], like(field(s, ^key), ^"%#{value}"))
+                |> where([s], like(field(s, ^key), ^"#{value}"))
 
               _ ->
                 query


### PR DESCRIPTION
汎用検索のlike検索の仕様変更に伴い、変更を加えています。
曖昧検索、前方一致、後方一致はコード側では全て同じ処理を行うようにし、ユーザー側で"%"をつけることで、検索方法を選択できるようにしています。
###
forward_like, backward_like検索処理の削除。
like検索において、コード内での"%"の付与部分を削除。